### PR TITLE
Switch PullRequestHandler to use pull_request trigger

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -1,5 +1,6 @@
 {
   "type": "PTE",
   "templateUrl": "https://github.com/microsoft/AL-Go-PTE@preview",
-  "templateSha": "becb26e1f895fb75145bbc10535afb19c09bff5c"
+  "templateSha": "becb26e1f895fb75145bbc10535afb19c09bff5c",
+  "PullRequestTrigger": "pull_request"
 }

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -1,7 +1,7 @@
 name: 'Pull Request Build'
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ 'main' ]
 
 concurrency:


### PR DESCRIPTION
This PR switches the PullRequestHandler workflow to use the pull_request trigger instead of pull_request_target.

Changes:
- Added PullRequestTrigger setting to AL-Go-Settings.json
- Updated PullRequestHandler.yaml trigger